### PR TITLE
Change service check for additional OSes

### DIFF
--- a/recipes/collector_sidecar.rb
+++ b/recipes/collector_sidecar.rb
@@ -47,9 +47,9 @@ execute 'install service graylog-collector-sidecar' do
   notifies :restart, 'service[collector-sidecar]'
   case node['platform']
   when 'ubuntu'
-    not_if { File.exist?('/etc/init/collector-sidecar.conf') }
+    not_if { File.exists?('/etc/systemd/system/collector-sidecar.service') || File.exists?('/etc/init/collector-sidecar.conf') }
   when 'debian', 'redhat', 'centos'
-    not_if { File.exist?('/etc/systemd/system/collector-sidecar.service') }
+    not_if { File.exists?('/etc/systemd/system/collector-sidecar.service') ||  File.exists?('/etc/init.d/collector-sidecar') }
   end
 end
 


### PR DESCRIPTION
Ran into an issue in usage, using the sidecar recipe on Ubuntu 16.04, it failed if the sidecar was already installed because the file check didn't exist for systemd. The same goes for [RHEL|OEL|CENTOS]7. There may be a better way to do this.